### PR TITLE
Add and auto-update IsAvailable column in movies grid

### DIFF
--- a/HobbyManiaManager/Forms/Movie/CatalogForm.cs
+++ b/HobbyManiaManager/Forms/Movie/CatalogForm.cs
@@ -25,6 +25,8 @@ namespace HobbyManiaManager
                 .ToList();
 
             ConfigureMoviesDatagrid();
+            RefreshMoviesGrid();
+            movieUserControl._refreshAction = () => RefreshMoviesGrid();
         }
 
         private void ConfigureMoviesDatagrid()
@@ -47,6 +49,13 @@ namespace HobbyManiaManager
                 var selected = _moviesRepository.GetById(id);
                 movieUserControl.Load(selected);
             }
+        }
+
+        private void RefreshMoviesGrid()
+        {
+            dataGridViewMoviesList.DataSource = _moviesRepository.GetAll()
+                .Select(m => new MovieDataGridViewModel(m))
+                .ToList();
         }
     }
 }

--- a/HobbyManiaManager/Forms/Movie/MovieUserControl.cs
+++ b/HobbyManiaManager/Forms/Movie/MovieUserControl.cs
@@ -13,6 +13,8 @@ namespace HobbyManiaManager
         private CultureInfo cultureInfo;
         private RentalService service;
         private Movie Movie;
+        public Action _refreshAction;
+
 
         public MovieUserControl()
         {
@@ -81,6 +83,8 @@ namespace HobbyManiaManager
         {
             var rentalForm = new RentalForm(Movie, this);
             rentalForm.ShowDialog();
+            _refreshAction?.Invoke();
+            this.Refresh();
         }
     }
 }

--- a/HobbyManiaManager/ViewModels/MovieDataGridViewModel.cs
+++ b/HobbyManiaManager/ViewModels/MovieDataGridViewModel.cs
@@ -7,12 +7,15 @@ namespace HobbyManiaManager.ViewModels
     {
         public MovieDataGridViewModel(Movie m)
         {
+            IsAvailable = new RentalService().IsAvailable(m);
             Id = m.Id;
             Title = m.Title;
             OriginalTitle = m.OriginalTitle;
             ReleaseDate = m.ReleaseDate;
             VoteAverage = Math.Round(m.VoteAverage *10);
         }
+
+        public bool IsAvailable { get; set; }
 
         public int Id { get; set; }
 


### PR DESCRIPTION
- Added new column with checkmarks showing movie availability status
- Column gets data from RentalService when loading
- Now automatically updates when:
  * User rents a movie (checkmark disappears)
  * User returns a movie (checkmark reappears)
- Connected MovieUserControl to refresh grid after rental actions
- Keeps the display synced with actual availability"
![Captura2](https://github.com/user-attachments/assets/dbf0b969-177d-4cf4-992a-afa437a3bb97)
![Captura](https://github.com/user-attachments/assets/cd9f80a3-8b35-4718-b911-185c9f6f0fde)
